### PR TITLE
DRAFT: Add factory class that allow to ctreate services from globals variables

### DIFF
--- a/django_socio_grpc/utils/global_variables_service_factory.py
+++ b/django_socio_grpc/utils/global_variables_service_factory.py
@@ -1,15 +1,15 @@
 from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
 
 
-def assert_method_didnt_exist(methods_names: set, name: str, all_attributes: dict) -> None:
+def assert_methods_dont_exist(methods_names: set, name: str, all_attributes: dict) -> None:
     intersect = methods_names.intersection(set(all_attributes.keys()))
     assert (
         not intersect
     ), f"Method(s) {', '.join(list(intersect))} will be automatically implement by\
-        'SocioGlobalsServiceFactory'. Don't implement it yourself in {name} or they will be overrided."
+        'ConstantsToMapMessageServiceFactory'. Don't implement it yourself in {name} or they will be overrided."
 
 
-class SocioGlobalsServiceFactory(type):
+class ConstantsToMapMessageServiceFactory(type):
     """
     Metaclass used as a factory for building Class used as
     namespaced model constants variables.
@@ -17,27 +17,27 @@ class SocioGlobalsServiceFactory(type):
 
     default_protobuff_map_attribute = "value"
     metaclass_method_definition = set(
-        ["avaible_choices", "get_as_choices", "get_as_message", "get_as_service"]
+        ["available_choices", "get_as_choices", "get_as_message", "get_as_service"]
     )
 
     def __new__(cls, *args, **kwargs):
         name, parents, attributes = args[0], args[1], args[2]
         # Check user contract: no inheritance (unexpected method definition or overriding),
         # no reserved method definition.
-        assert not parents, "'SocioGlobalsServiceFactory' type doesn't support inheritance."
-        assert_method_didnt_exist(
-            SocioGlobalsServiceFactory.metaclass_method_definition, name, attributes
+        assert not parents, "'ConstantsToMapMessageServiceFactory' type doesn't support inheritance."
+        assert_methods_dont_exist(
+            ConstantsToMapMessageServiceFactory.metaclass_method_definition, name, attributes
         )
 
         # Get user defined class attributes
-        attributes["avaible_choices"] = {
+        attributes["available_choices"] = {
             attr_name: value
             for attr_name, value in attributes.items()
             if isinstance(value, str) and not attr_name.startswith("__")
         }
         # Building classmethods
 
-        # If user have no defined meta: we create it.
+        # If user has no defined Meta raise error
         future_cls_meta = attributes.get("Meta", False)
         assert getattr(
             future_cls_meta, "service_pb2", False
@@ -47,7 +47,7 @@ class SocioGlobalsServiceFactory(type):
         proto_message_name = getattr(future_cls_meta, "proto_message_name", None) or f"{name}"
         protobuff_map_attribute_name = (
             getattr(future_cls_meta, "protobuff_map_attribute_name", False)
-            or SocioGlobalsServiceFactory.default_protobuff_map_attribute
+            or ConstantsToMapMessageServiceFactory.default_protobuff_map_attribute
         )
         service_method = getattr(future_cls_meta, "service_method_name", None) or f"List{name}"
         service_request = getattr(future_cls_meta, "service_request", None) or {
@@ -66,11 +66,11 @@ class SocioGlobalsServiceFactory(type):
         attributes["_service_response"] = service_response
 
         # Define proto map attribute name and proto methods
-        attributes["get_as_message"] = classmethod(SocioGlobalsServiceFactory.get_as_message)
-        attributes["get_as_method"] = classmethod(SocioGlobalsServiceFactory.get_as_method)
-        attributes["get_as_service"] = classmethod(SocioGlobalsServiceFactory.get_as_service)
-        # Get as choite classmethod
-        get_as_choices_method = lambda x: tuple(x.avaible_choices.items())
+        attributes["get_as_message"] = classmethod(ConstantsToMapMessageServiceFactory.get_as_message)
+        attributes["get_as_method"] = classmethod(ConstantsToMapMessageServiceFactory.get_as_method)
+        attributes["get_as_service"] = classmethod(ConstantsToMapMessageServiceFactory.get_as_service)
+        # Get as choice classmethod
+        get_as_choices_method = lambda x: tuple(x.available_choices.items())
         attributes["get_as_choices"] = classmethod(get_as_choices_method)
         return type(name, (), attributes)
 
@@ -92,14 +92,14 @@ class SocioGlobalsServiceFactory(type):
         """
         Return tuple for the CharField choices `params`.
         """
-        return tuple(future_cls.avaible_choices.items())
+        return tuple(future_cls.available_choices.items())
 
     def get_as_service(future_cls) -> GeneratedProtocolMessageType:
         """
         Return a Message that can be used in ModelService
         """
         proto_message = getattr(future_cls.Meta.service_pb2, future_cls._proto_message_name)()
-        for key, value in future_cls.avaible_choices.items():
+        for key, value in future_cls.available_choices.items():
             proto_message.value[key] = value
         return proto_message
 

--- a/django_socio_grpc/utils/global_variables_service_factory.py
+++ b/django_socio_grpc/utils/global_variables_service_factory.py
@@ -1,0 +1,115 @@
+from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
+
+
+def assert_method_didnt_exist(methods_names: set, name: str, all_attributes: dict) -> None:
+    intersect = methods_names.intersection(set(all_attributes.keys()))
+    assert (
+        not intersect
+    ), f"Method(s) {', '.join(list(intersect))} will be automatically implement by\
+        'SocioGlobalsServiceFactory'. Don't implement it yourself in {name} or they will be overrided."
+
+
+class SocioGlobalsServiceFactory(type):
+    """
+    Metaclass used as a factory for building Class used as
+    namespaced model constants variables.
+    """
+
+    default_protobuff_map_attribute = "value"
+    metaclass_method_definition = set(
+        ["avaible_choices", "get_as_choices", "get_as_message", "get_as_service"]
+    )
+
+    def __new__(cls, *args, **kwargs):
+        name, parents, attributes = args[0], args[1], args[2]
+        # Check user contract: no inheritance (unexpected method definition or overriding),
+        # no reserved method definition.
+        assert not parents, "'SocioGlobalsServiceFactory' type doesn't support inheritance."
+        assert_method_didnt_exist(
+            SocioGlobalsServiceFactory.metaclass_method_definition, name, attributes
+        )
+
+        # Get user defined class attributes
+        attributes["avaible_choices"] = {
+            attr_name: value
+            for attr_name, value in attributes.items()
+            if isinstance(value, str) and not attr_name.startswith("__")
+        }
+        # Building classmethods
+
+        # If user have no defined meta: we create it.
+        future_cls_meta = attributes.get("Meta", False)
+        assert getattr(
+            future_cls_meta, "service_pb2", False
+        ), f"'{name}' class must define a Meta with at least `service_pb2` wich contains your grpc module ie. `myapp.grpc.myapp_pb2`"
+        print(dir(future_cls_meta))
+        # Extract customs from class Meta
+        proto_message_name = getattr(future_cls_meta, "proto_message_name", None) or f"{name}"
+        protobuff_map_attribute_name = (
+            getattr(future_cls_meta, "protobuff_map_attribute_name", False)
+            or SocioGlobalsServiceFactory.default_protobuff_map_attribute
+        )
+        service_method = getattr(future_cls_meta, "service_method_name", None) or f"List{name}"
+        service_request = getattr(future_cls_meta, "service_request", None) or {
+            "is_stream": False,
+            "message": f"{proto_message_name}",
+        }
+        service_response = getattr(future_cls_meta, "service_response", None) or {
+            "is_stream": False,
+            "message": f"{proto_message_name}",
+        }
+        # Record attributes below as private attributes.
+        attributes["_proto_message_name"] = proto_message_name
+        attributes["_protobuff_map_attribute_name"] = protobuff_map_attribute_name
+        attributes["_service_method"] = service_method
+        attributes["_service_request"] = service_request
+        attributes["_service_response"] = service_response
+
+        # Define proto map attribute name and proto methods
+        attributes["get_as_message"] = classmethod(SocioGlobalsServiceFactory.get_as_message)
+        attributes["get_as_method"] = classmethod(SocioGlobalsServiceFactory.get_as_method)
+        attributes["get_as_service"] = classmethod(SocioGlobalsServiceFactory.get_as_service)
+        # Get as choite classmethod
+        get_as_choices_method = lambda x: tuple(x.avaible_choices.items())
+        attributes["get_as_choices"] = classmethod(get_as_choices_method)
+        return type(name, (), attributes)
+
+    def get_as_message(future_cls):
+        """
+        Build message expected on `grpc_messages` in the Model.
+        """
+
+        proto_message_definition = {
+            future_cls._proto_message_name: [
+                "__custom__map<string, string>__{}__".format(
+                    future_cls._protobuff_map_attribute_name
+                )
+            ]
+        }
+        return proto_message_definition
+
+    def get_as_choices(future_cls) -> tuple:
+        """
+        Return tuple for the CharField choices `params`.
+        """
+        return tuple(future_cls.avaible_choices.items())
+
+    def get_as_service(future_cls) -> GeneratedProtocolMessageType:
+        """
+        Return a Message that can be used in ModelService
+        """
+        proto_message = getattr(future_cls.Meta.service_pb2, future_cls._proto_message_name)()
+        for key, value in future_cls.avaible_choices.items():
+            proto_message.value[key] = value
+        return proto_message
+
+    def get_as_method(future_cls) -> dict:
+        """
+        Build dict expected on `grpc_methods` in the Model. 
+        """
+        return {
+            future_cls._service_method: {
+                "request": future_cls._service_request,
+                "response": future_cls._service_response,
+            }
+        }

--- a/docs/tutorial/hardcoded_variables_service.rst
+++ b/docs/tutorial/hardcoded_variables_service.rst
@@ -1,33 +1,44 @@
 .. hardcoded_variables_service:
 
-Globals Variables Service
+Constants Service
 ===========================
 
-Sometimes, we need to create globals variables. Instead to copy and paste them on your front-end as JSON
-you should use `GlobalsServiceFactory`
+Sometimes, we need to create shared constants variables. Instead to copy and paste them on your front-end as JSON
+you should use `ConstantsToMapMessageServiceFactory`
 
 Usage
 -------
+
+Define a class inherit from `ConstantsToMapMessageServiceFactory` in ex you managing stock and you want to define status for your product:
+ 
+```python
+    class ProductType(metaclass=ConstantsToMapMessageServiceFactory):
+        # product status code = food status label
+        DF = "Dry Food"
+        PF = "Perishable Food"
+        NE = "No edible"
+```
+
+and this class (here ProductType) will offer attributes and methods below. 
 
 Methods
 ^^^^^^^^^
 
 - `get_as_choices`: which can be used ie. on Django CharField in `choices` keyword param.
+  in our `ProductType` class a tuple containing `(("DF", "Dry Food",)("PF", "Perishable Food",),)`
 
-- `get_as_method` will be used on `Meta.grpc_methods` of the corresponding models
-  for allow proto method definition.
+- `get_as_method` that you must be use on `Meta.grpc_methods` of the corresponding models
+  for generate proto method definition.
 
-- `get_as_message` will be used on `Meta.grpc_messages` of the corresponding
-  models for allow proto message deinition.
+- `get_as_message`  that you must be use on `Meta.grpc_messages` of the corresponding
+  models for generate proto message definition.
 
-- `get_as_service` must be called on the corresponding ModelService inside a
-  simple `List<your class name>` method define by him. 
+- `get_as_service` must be called on the corresponding `ModelService` inside the method `List<your class name>` method you will define. 
 
 Attributes
 ^^^^^^^^^^^^
 
-- `avaible_choices: dict` allow you to do things with attributes you have defined
-    exposed py a dict.
+- `available_choices: dict` allow you to READ attributes you have defined as dict. 
 
 Customize
 ^^^^^^^^^^^^
@@ -58,7 +69,7 @@ For example we want to define product type for our product models.
 - `models.py`
 
 ```python
-    class ProductType(metaclass=GlobalsServiceFactory):
+    class ProductType(metaclass=ConstantsToMapMessageServiceFactory):
         DF = "Dry Food"
         PF = "Perishable Food"
         NE = "No edible"
@@ -75,7 +86,7 @@ For example we want to define product type for our product models.
             grpc_methods = {**ProductType.get_as_method()}
 
 ```
-- `view.py` (or where you hav defined your services)
+- `view.py` (or where you havedefined your services)
 
 ```python
     from product.models import Product

--- a/docs/tutorial/hardcoded_variables_service.rst
+++ b/docs/tutorial/hardcoded_variables_service.rst
@@ -1,0 +1,98 @@
+.. hardcoded_variables_service:
+
+Globals Variables Service
+===========================
+
+Sometimes, we need to create globals variables. Instead to copy and paste them on your front-end as JSON
+you should use `GlobalsServiceFactory`
+
+Usage
+-------
+
+Methods
+^^^^^^^^^
+
+- `get_as_choices`: which can be used ie. on Django CharField in `choices` keyword param.
+
+- `get_as_method` will be used on `Meta.grpc_methods` of the corresponding models
+  for allow proto method definition.
+
+- `get_as_message` will be used on `Meta.grpc_messages` of the corresponding
+  models for allow proto message deinition.
+
+- `get_as_service` must be called on the corresponding ModelService inside a
+  simple `List<your class name>` method define by him. 
+
+Attributes
+^^^^^^^^^^^^
+
+- `avaible_choices: dict` allow you to do things with attributes you have defined
+    exposed py a dict.
+
+Customize
+^^^^^^^^^^^^
+
+By default, the class will create a message named "<your child class name>" and a service with "List<your child class name>"
+If you want twist it, your child can redefined this attributes (and more) in `class Meta`.
+
+
+- `protobuff_map_attribute` (default: `value`) root key returned in
+    gRPC response (message attribute on proto).
+
+- `service_method_name` (default: `List<your child class name>`) gRPC
+    method name. Will you must define in your ModelService.
+
+- `proto_message_name` (default: `<your class name>`) proto message as it will be defined on .proto
+
+- `service_request` (default: `{"is_stream": False, "message": <your child class name>}`) 
+
+- `service_response` (default: `{"is_stream": False, "message": <your child class name>}`)
+
+
+
+Example
+---------
+
+For example we want to define product type for our product models. 
+
+- `models.py`
+
+```python
+    class ProductType(metaclass=GlobalsServiceFactory):
+        DF = "Dry Food"
+        PF = "Perishable Food"
+        NE = "No edible"
+
+    class Product(BaseModel):
+        ProductType = ProductType
+        product_type = models.CharField(
+            choices=ProductType.get_as_choices()
+        )
+        class Meta:
+            grpc_messages = {
+                **ProductType.get_as_message(),
+            }
+            grpc_methods = {**ProductType.get_as_method()}
+
+```
+- `view.py` (or where you hav defined your services)
+
+```python
+    from product.models import Product
+
+    class ProductService(generics.ModelService):
+
+        def ListProductsType(self, *args):
+            return Product.ProductType.get_as_service()
+```
+- GRPC call on `ListProductsType` will return:
+
+```json
+    {
+    "value": {
+        "DF" : "Dry Food"
+        "PF" : "Perishable Food"
+        "NE" : "No edible"
+        }
+    }
+```

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -16,3 +16,4 @@ source code in `tutorial example`_.
    building_services
    using_generics
    writing_tests
+   hardcoded_variables_service

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -16,4 +16,3 @@ source code in `tutorial example`_.
    building_services
    using_generics
    writing_tests
-   hardcoded_variables_service


### PR DESCRIPTION
A simple metaclass useful to provide access from the front to variables defined in the Charfield template field like "choice" or even to global variables without having to maintain them in several repositories. 
This allows to have a single source of truth for the globals while standardizing the answer to be given in this particular use case. 
I chose to define a metaclass in order to offer a declarative API and to be able to guide the user by contracting the starting state of his class.
Obviously open to discussion. 