### PR TITLE
Fix/metadata not overrided

### DIFF
--- a/django_socio_grpc/tests/grpc_test_utils/fake_grpc.py
+++ b/django_socio_grpc/tests/grpc_test_utils/fake_grpc.py
@@ -257,7 +257,7 @@ class FakeAioCall(FakeBaseCall):
         # INFO - AM - 28/07/2022 - request is not None at first call but then at each read is transformed to None. So we only assign it if not None
         if request is not None:
             self._request = request
-        if self._metadata is None and metadata is not None:
+        if metadata is not None:
             self._metadata = metadata
             self._context._invocation_metadata.extend((_Metadatum(k, v) for k, v in metadata))
         # TODO - AM - 18/02/2022 - Need to launch _real_method in a separate thread to be able to work with stream stream object
@@ -293,7 +293,7 @@ class FakeFullAioCall(FakeBaseCall):
         # INFO - AM - 28/07/2022 - request is not None at first call but then at each read is transformed to None. So we only assign it if not None
         if request is not None:
             self._request = request
-        if self._metadata is None and metadata is not None:
+        if metadata is not None:
             self._metadata = metadata
             self._context._invocation_metadata.extend((_Metadatum(k, v) for k, v in metadata))
 

--- a/django_socio_grpc/tests/test_filtering.py
+++ b/django_socio_grpc/tests/test_filtering.py
@@ -1,6 +1,6 @@
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from fakeapp.grpc.fakeapp_pb2 import UnitTestModelListRequest
 from fakeapp.grpc.fakeapp_pb2_grpc import (
     UnitTestModelControllerStub,
@@ -9,29 +9,43 @@ from fakeapp.grpc.fakeapp_pb2_grpc import (
 from fakeapp.models import UnitTestModel
 from fakeapp.services.unit_test_model_service import UnitTestModelService
 
-from .grpc_test_utils.fake_grpc import FakeGRPC
+from .grpc_test_utils.fake_grpc import FakeFullAIOGRPC
 
 
+@override_settings(GRPC_FRAMEWORK={"GRPC_ASYNC": True})
 class TestFiltering(TestCase):
     def setUp(self):
         for idx in range(10):
             title = "z" * (idx + 1)
             text = chr(idx + ord("a")) + chr(idx + ord("b")) + chr(idx + ord("c"))
             UnitTestModel(title=title, text=text).save()
-        self.fake_grpc = FakeGRPC(
+
+        UnitTestModel(title="zzzz", text=text).save()
+        self.fake_grpc = FakeFullAIOGRPC(
             add_UnitTestModelControllerServicer_to_server, UnitTestModelService.as_servicer()
         )
 
     def tearDown(self):
         self.fake_grpc.close()
 
-    def test_django_filter(self):
+    async def test_django_filter(self):
         grpc_stub = self.fake_grpc.get_fake_stub(UnitTestModelControllerStub)
         request = UnitTestModelListRequest()
         filter_as_dict = {"title": "zzzzzzz"}
         metadata = (("FILTERS", (json.dumps(filter_as_dict))),)
-        response = grpc_stub.List(request=request, metadata=metadata)
+        response = await grpc_stub.List(request=request, metadata=metadata)
 
         self.assertEqual(len(response.results), 1)
         # responses_as_list[0] is type of django_socio_grpc.tests.grpc_test_utils.unittest_pb2.Test
         self.assertEqual(response.results[0].title, "zzzzzzz")
+
+        # INFO - AM - 05/02/2023 - This test verify that metadata are well overiden in unit test
+        grpc_stub = self.fake_grpc.get_fake_stub(UnitTestModelControllerStub)
+        request = UnitTestModelListRequest()
+        filter_as_dict = {"title": "zzzz"}
+        metadata = (("FILTERS", (json.dumps(filter_as_dict))),)
+        response = await grpc_stub.List(request=request, metadata=metadata)
+
+        self.assertEqual(len(response.results), 2)
+        # responses_as_list[0] is type of django_socio_grpc.tests.grpc_test_utils.unittest_pb2.Test
+        self.assertEqual(response.results[0].title, "zzzz")


### PR DESCRIPTION
Need to be tested on some projects that test stream with metadata. The condiciton removed was here to avoid metadata reinitialized in stream as metadata are only passed the first call and not the others.