### PR TITLE
fix: #291 -  including_default_value_without_presence deprecation

### DIFF
--- a/django_socio_grpc/protobuf/json_format.py
+++ b/django_socio_grpc/protobuf/json_format.py
@@ -10,7 +10,6 @@ def message_to_dict(message, **kwargs):
     Uses the default `google.protobuf.json_format.MessageToDict` function.
     Adds None values for optional fields that are not set.
     """
-    kwargs.setdefault("including_default_value_fields", True)
     kwargs.setdefault("preserving_proto_field_name", True)
 
     return MessageToDict(message, **kwargs)


### PR DESCRIPTION
This fixes issue #291 - including_default_value_without_presence deprecation in json_format.py.

Please also update the poetry.fix 
grpcio >= 1.64.0 (and all related packages)
protobuf >= 5.26.1 

Merci.