### PR TITLE
Bugfix: Only keep True value in auth_responses

### DIFF
--- a/django_socio_grpc/services/base_service.py
+++ b/django_socio_grpc/services/base_service.py
@@ -68,7 +68,9 @@ class Service(GRPCActionMixin):
 
     def resolve_user(self):
         auth_responses = [
-            auth().authenticate(self.context) for auth in self.authentication_classes
+            response
+            for auth in self.authentication_classes
+            if (response := auth().authenticate(self.context))
         ]
         if auth_responses:
             return auth_responses[0]

--- a/django_socio_grpc/tests/test_authentication.py
+++ b/django_socio_grpc/tests/test_authentication.py
@@ -15,6 +15,11 @@ class FakeAuthentication:
         return ({"email": "john.doe@johndoe.com"}, context.META.get("HTTP_AUTHORIZATION"))
 
 
+class FakeNotHandlingAuthentication:
+    def authenticate(self, context):
+        return None
+
+
 class DummyService(Service):
     def DummyMethod(service, request, context):
         pass
@@ -52,6 +57,15 @@ class TestAuthenticationUnitary(TestCase):
         dummy_service.context = FakeContext()
         dummy_service.context.META = {"HTTP_AUTHORIZATION": "faketoken"}
         dummy_service.authentication_classes = [FakeAuthentication]
+
+        auth_user_tuple = dummy_service.resolve_user()
+        self.assertEqual(auth_user_tuple, ({"email": "john.doe@johndoe.com"}, "faketoken"))
+
+    def test_resolve_user_with_multiple_authentications(self):
+        dummy_service = DummyService()
+        dummy_service.context = FakeContext()
+        dummy_service.context.META = {"HTTP_AUTHORIZATION": "faketoken"}
+        dummy_service.authentication_classes = [FakeNotHandlingAuthentication, FakeAuthentication]
 
         auth_user_tuple = dummy_service.resolve_user()
         self.assertEqual(auth_user_tuple, ({"email": "john.doe@johndoe.com"}, "faketoken"))


### PR DESCRIPTION
# Use multiple authentication backend

For example:
```python
GRPC_FRAMEWORK = {
    "DEFAULT_AUTHENTICATION_CLASSES": [
        "poc.authentication.ServiceTokenAuthenticationBackend",
        "poc.authentication.AccessTokenAuthenticationBackend",
    ],
    // ...
}
```

Scenario: Use two authentication backends for validating different token (service token and user access_token) using different token header
- service token: "Authorization: Service <service_token>"
- access token: "Authorization: Bearer <access_token>"

One of the authentication backend will return `None` if it should not handle the token.

Current implementation has problems if the value `auth_responses` is like `[None, (<User>, None)]`, `auth_responses[0]` returns `None`, which is wrong, since one of the authentication backend returns a user_auth_tuple

# Expected behavior
`resolve_user` should return the valid user_auth_tuple returned by one of the authentication backend

# Fix
Only keep True value in `auth_responses`

