### PR TITLE
fix image build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.10 AS builder
+FROM python:3.10 AS builder
 
 ENV PYTHONUNBUFFERED 1
 
@@ -12,7 +12,7 @@ RUN sed -i 's/^# *\(fr_FR.UTF-8\)/\1/' /etc/locale.gen
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
 RUN locale-gen
 
-RUN pip install --no-cache-dir psycopg2 poetry
+RUN pip install --no-cache-dir psycopg2 'poetry<2.0.0'
 
 RUN poetry config virtualenvs.create false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ myst-parser = "^2.0.0"
 sphinx-autodoc2 = "^0.5"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0,<2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
# Remove the platform parameter from Dockerfile
We should remove the fixed `--platform=linux/amd64` from Dockefile to allow docker to choose right architecture when pulling the image.

If this change affects the github action, we should specify the platform parameter on github action task

# Fix poetry version issue
When I try to build the image using `docker compose build` today, it failed due to a breaking change of poetry 2.0.0. 

We need to put a constrain of 'poetry<2.0.0' for now.

```
docker compose build

> [django-socio-grpc server 1/1] RUN poetry install:
0.493
0.502 The Poetry configuration is invalid:
0.502   - project must contain ['name'] properties
```

Others are experiencing [the same issue](https://github.com/HumanSignal/label-studio/issues/6851)